### PR TITLE
Bug: Resulting output needs to be a string

### DIFF
--- a/login_script.js
+++ b/login_script.js
@@ -36,7 +36,7 @@ module.exports = (oauthProvider, message, content) => `
     // send message to main window with da app
     window.opener.postMessage(
       'authorization:${oauthProvider}:${message}:${JSON.stringify(content)}',
-      ${appOrigin} || e.origin
+      '${appOrigin}' || e.origin
     )
   }
   window.addEventListener("message", recieveMessage, false)


### PR DESCRIPTION
This interpolation needs to be handed off as a string to the postmessage call 